### PR TITLE
Added import to include new NetworkDriver location in napalm 2.0.0+

### DIFF
--- a/napalm_fortios/fortios.py
+++ b/napalm_fortios/fortios.py
@@ -16,12 +16,15 @@ from __future__ import unicode_literals
 import re
 from pyFG.fortios import FortiOS, FortiConfig, logger
 from pyFG.exceptions import FailedCommit, CommandExecutionException
-from napalm_base.base import NetworkDriver
 from napalm_base.exceptions import ReplaceConfigException, MergeConfigException
 from napalm_base.utils.string_parsers import colon_separated_string_to_dict,\
                                              convert_uptime_string_seconds
 from napalm_base.utils import py23_compat
 
+try:
+    from napalm.base.base import NetworkDriver
+except ImportError:
+    from napalm_base.base import NetworkDriver
 
 class FortiOSDriver(NetworkDriver):
     def __init__(self, hostname, username, password, timeout=60, optional_args=None):

--- a/napalm_fortios/fortios.py
+++ b/napalm_fortios/fortios.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
     from napalm_base.base import NetworkDriver
 
+
 class FortiOSDriver(NetworkDriver):
     def __init__(self, hostname, username, password, timeout=60, optional_args=None):
         self.hostname = hostname


### PR DESCRIPTION
napalm 2.0.0+ has a new location for the base functionality, including NetworkDriver which is now under napalm.base.base.
napalm 2.0.0+ is also checking that NetworkDriver is inheriting from napalm.base.base.NetworkDriver.

Due to a bug related to community drivers in napalm this change will actually start to work correctly with version 2.2.1. 
The fix for the bug is merged under: https://github.com/napalm-automation/napalm/pull/589

