### PR TITLE
Fix for pip10, adjust to napalm.base, remove py23 support

### DIFF
--- a/napalm_fortios/fortios.py
+++ b/napalm_fortios/fortios.py
@@ -16,16 +16,11 @@ from __future__ import unicode_literals
 import re
 from pyFG.fortios import FortiOS, FortiConfig, logger
 from pyFG.exceptions import FailedCommit, CommandExecutionException
-from napalm_base.exceptions import ReplaceConfigException, MergeConfigException
-from napalm_base.utils.string_parsers import colon_separated_string_to_dict,\
+from napalm.base.exceptions import ReplaceConfigException, MergeConfigException
+from napalm.base.utils.string_parsers import colon_separated_string_to_dict,\
                                              convert_uptime_string_seconds
-from napalm_base.utils import py23_compat
-import napalm_base.helpers
-
-try:
-    from napalm.base.base import NetworkDriver
-except ImportError:
-    from napalm_base.base import NetworkDriver
+import napalm.base.helpers
+from napalm.base.base import NetworkDriver
 
 
 class FortiOSDriver(NetworkDriver):
@@ -172,7 +167,7 @@ class FortiOSDriver(NetworkDriver):
 
             return {
                 'startup': u"",
-                'running': py23_compat.text_type(text_result),
+                'running': str(text_result),
                 'candidate': u"",
             }
 
@@ -196,12 +191,12 @@ class FortiOSDriver(NetworkDriver):
                                              vdom='global')['domain']
 
         return {
-            'vendor': py23_compat.text_type('Fortigate'),
-            'os_version': py23_compat.text_type(system_status['Version'].split(',')[0].split()[1]),
+            'vendor': str('Fortigate'),
+            'os_version': str(system_status['Version'].split(',')[0].split()[1]),
             'uptime': convert_uptime_string_seconds(performance_status['Uptime']),
-            'serial_number': py23_compat.text_type(system_status['Serial-Number']),
-            'model': py23_compat.text_type(system_status['Version'].split(',')[0].split()[0]),
-            'hostname': py23_compat.text_type(system_status['Hostname']),
+            'serial_number': str(system_status['Serial-Number']),
+            'model': str(system_status['Version'].split(',')[0].split()[0]),
+            'hostname': str(system_status['Hostname']),
             'fqdn': u'{}.{}'.format(system_status['Hostname'], domain),
             'interface_list': interface_list
         }
@@ -247,7 +242,7 @@ class FortiOSDriver(NetworkDriver):
                     elif line.startswith('Link'):
                         parsed_data['is_up'] = line.split('\t')[-1] is 'up'
                     elif line.startswith('Current_HWaddr'):
-                        parsed_data['mac_address'] = py23_compat.text_type(line.split('\t')[-1])
+                        parsed_data['mac_address'] = str(line.split('\t')[-1])
                 parsed_data['is_enabled'] = True
                 parsed_data['description'] = u''
                 parsed_data['last_flapped'] = -1.0
@@ -260,7 +255,7 @@ class FortiOSDriver(NetworkDriver):
                     elif line.startswith('PHY Speed'):
                         parsed_data['speed'] = int(line.split(':')[-1])
                     elif line.startswith('Current_HWaddr'):
-                        parsed_data['mac_address'] = py23_compat.text_type(line.split(' ')[-1])
+                        parsed_data['mac_address'] = str(line.split(' ')[-1])
                 parsed_data['description'] = u''
                 parsed_data['last_flapped'] = -1.0
             interface_statistics[interface] = parsed_data
@@ -323,16 +318,16 @@ class FortiOSDriver(NetworkDriver):
             policy_item['position'] = position
             policy_item['packet_hits'] = -1
             policy_item['byte_hits'] = -1
-            policy_item['id'] = py23_compat.text_type(key)
+            policy_item['id'] = str(key)
             policy_item['enabled'] = enabled
-            policy_item['schedule'] = py23_compat.text_type(policy[key]['schedule'])
-            policy_item['log'] = py23_compat.text_type(logtraffic)
-            policy_item['l3_src'] = py23_compat.text_type(policy[key]['srcaddr'])
-            policy_item['l3_dst'] = py23_compat.text_type(policy[key]['dstaddr'])
-            policy_item['service'] = py23_compat.text_type(policy[key]['service'])
-            policy_item['src_zone'] = py23_compat.text_type(policy[key]['srcintf'])
-            policy_item['dst_zone'] = py23_compat.text_type(policy[key]['dstintf'])
-            policy_item['action'] = py23_compat.text_type(action)
+            policy_item['schedule'] = str(policy[key]['schedule'])
+            policy_item['log'] = str(logtraffic)
+            policy_item['l3_src'] = str(policy[key]['srcaddr'])
+            policy_item['l3_dst'] = str(policy[key]['dstaddr'])
+            policy_item['service'] = str(policy[key]['service'])
+            policy_item['src_zone'] = str(policy[key]['srcintf'])
+            policy_item['dst_zone'] = str(policy[key]['dstintf'])
+            policy_item['action'] = str(action)
             default_policy[key].append(policy_item)
 
             position = position + 1
@@ -375,7 +370,7 @@ class FortiOSDriver(NetworkDriver):
                              self._execute_command_with_vdom(command_detail.format(neighbor))]
             m = re.search('remote router id (.+?)\n', '\n'.join(detail_output))
             if m:
-                neighbor_dict['remote_id'] = py23_compat.text_type(m.group(1))
+                neighbor_dict['remote_id'] = str(m.group(1))
             else:
                 raise Exception('cannot find remote router id for %s' % neighbor)
 
@@ -400,7 +395,7 @@ class FortiOSDriver(NetworkDriver):
 
         return {
             'global': {
-                'router_id': py23_compat.text_type(bgp_sum[0].split()[3]),
+                'router_id': str(bgp_sum[0].split()[3]),
                 'peers': peers
             }
         }
@@ -518,7 +513,7 @@ class FortiOSDriver(NetworkDriver):
                 address, age, mac, interface = line.split()
                 entry = {
                     "interface": interface,
-                    "mac": napalm_base.helpers.mac(mac).rstrip(),
+                    "mac": napalm.base.helpers.mac(mac).rstrip(),
                     "ip": address,
                     "age": age.replace("-", "-1"),
                 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-napalm-base>=0.23.0
+napalm
 pyFG>=0.49_1
 future
+ncclient==0.6.9


### PR DESCRIPTION
This adds the fix for pip 10> parse_requirements, adjusts to use napalm.base instead of napalm_base which allows napalm 3.x support and removes py23 backwards compatibility as python 2.3 is long since end of life.

This has been tested to be working minus an issue with pyFG. Due to pyFG also not implementing the pip 10> fixes the build will fail to install still unless you manually build a fixed version of pyFG prior to running pip3 install against napalm-fortios.

https://github.com/spotify/pyfg/pull/44
https://github.com/spotify/pyfg/pull/35
and https://github.com/spotify/pyfg/pull/47 all cover this fix, in hopes someone can get the attention of someone over at Spotify to merge.

A workaround for now is to git clone pyFG, modify the setup.py from:

```
from pip.req import parse_requirements
```

to

```
try:
    from pip._internal.req import parse_requirements
except ImportError:
    from pip.req import parse_requirements
```

then it can be installed using pip install successfully. This keeps backwards compatibility for those still relying upon older pip versions. This hopefully will bring napalm-fortios back into operation as I'd really like to see this project continue to operate.