### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-napalm-base>=0.23.0
+napalm
 pyFG>=0.49_1
 future


### PR DESCRIPTION
napalm-base is no longer supported and it's not possible to correct the pip install issue for pip version >10

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
